### PR TITLE
Modify chart values for staging deployment

### DIFF
--- a/charts/airbyte/ci.sh
+++ b/charts/airbyte/ci.sh
@@ -3,8 +3,8 @@
 set -e
 
 export RELEASE_NAME="${RELEASE_NAME:-airbyte}"
-export NAMESPACE="${NAMESPACE:-airbyte}"
-export INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-600s}"
+export NAMESPACE="${NAMESPACE:stg-airbyte}"
+export INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-1200s}"
 
 usage() {
   echo "Airbyte Helm Chart CI Script"

--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: airbyte-db-container
-          image: "{{ .Values.postgresql.image.repository }}:{{ ((.Values.global.image).tag) | default .Chart.AppVersion }}"
+          image: "{{ .Values.postgresql.image.repository }}:{{ (.Values.postgresql.image.tag) | default .Chart.AppVersion }}"
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.postgresqlDatabase }}
@@ -70,6 +70,7 @@ spec:
   - metadata:
       name: airbyte-volume-db
     spec:
+      storageClassName: cdk-cinder
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -18,6 +18,7 @@ spec:
       - metadata:
           name: airbyte-minio-pv-claim
         spec:
+          storageClassName: cdk-cinder
           accessModes: [ "ReadWriteOnce" ]
           resources:
             requests:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -1258,6 +1258,7 @@ postgresql:
   ## image.repository Repository for airbyte-db statefulset
   image:
     repository: airbyte/db
+    tag: dev-aa084c2cea
   # -- Airbyte Postgresql username
   postgresqlUsername: airbyte
   # -- Airbyte Postgresql password

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -163,7 +163,7 @@ serviceAccount:
 
 # -- Sets the AIRBYTE_VERSION environment variable. Defaults to Chart.AppVersion.
 ## If changing the image tags below, you should probably also update this.
-version: ""
+version: "0.50.47"
 
 ## @section Webapp Parameters
 


### PR DESCRIPTION
This PR modifies some values in the Airbyte helm chart to enable our staging deployment:
- Pins the app version to `0.50.47`
- Changes the k8s namespace.
- Updates the `airbyte-db` and `minio` storage class to use `cdk-cinder`.
- Updates the PostgreSQL image tag.

The staging deployment can be recreated by running:

```
cd charts/airbyte
./ci.sh install
```