### PR TITLE
Add OpenTelemetry deployment

### DIFF
--- a/opentelemetry/base/deployment.yaml
+++ b/opentelemetry/base/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-collector
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8889"
+    spec:
+      containers:
+        - command:
+            - "/otelcol"
+            - "--config=/conf/otel-collector-config.yaml"
+          image: "otel/opentelemetry-collector:0.96.0-amd64"
+          name: otel-collector
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 400Mi
+          ports:
+            - containerPort: 4317
+            - containerPort: 8889
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+      volumes:
+        - configMap:
+            name: otel-collector-conf
+            items:
+              - key: otel-collector-config
+                path: otel-collector-config.yaml
+          name: config

--- a/opentelemetry/base/deployment.yaml
+++ b/opentelemetry/base/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               cpu: "1"
               memory: 1Gi
             requests:
-              cpu: 200m
+              cpu: 500m
               memory: 400Mi
           ports:
             - containerPort: 4317

--- a/opentelemetry/base/kustomization.yaml
+++ b/opentelemetry/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/opentelemetry/base/service.yaml
+++ b/opentelemetry/base/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
+    - name: metrics
+      protocol: TCP
+      port: 8889
+  selector:
+    component: otel-collector

--- a/opentelemetry/overlays/production/configmap.yaml
+++ b/opentelemetry/overlays/production/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-conf
+  namespace: prod-airbyte
+  labels:
+    app: opentelemetry
+    component: otel-collector-conf
+data:
+  otel-collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      batch:
+      memory_limiter:
+        limit_mib: 1500
+        spike_limit_mib: 512
+        check_interval: 5s
+    exporters:
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        namespace: "prod-airbyte"
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]

--- a/opentelemetry/overlays/production/kustomization.yaml
+++ b/opentelemetry/overlays/production/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: prod-airbyte
+
+resources:
+  - ../../base
+  - configmap.yaml
+
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      - op: replace
+        path: /spec/template/metadata/namespace
+        value: prod-airbyte
+        - target:
+          kind: Service
+        patch: |
+          - op: replace
+            path: /metadata/namespace
+            value: prod-airbyte

--- a/opentelemetry/overlays/staging/configmap.yaml
+++ b/opentelemetry/overlays/staging/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-conf
+  namespace: stg-airbyte
+  labels:
+    app: opentelemetry
+    component: otel-collector-conf
+data:
+  otel-collector-config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      batch:
+      memory_limiter:
+        limit_mib: 1500
+        spike_limit_mib: 512
+        check_interval: 5s
+    exporters:
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        namespace: "stg-airbyte"
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]

--- a/opentelemetry/overlays/staging/kustomization.yaml
+++ b/opentelemetry/overlays/staging/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: stg-airbyte
+
+resources:
+  - ../../base
+  - configmap.yaml
+
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      - op: replace
+        path: /spec/template/metadata/namespace
+        value: stg-airbyte
+  - target:
+      kind: Service
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: stg-airbyte


### PR DESCRIPTION
This PR adds a deployment for the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/), which will collect metrics from Airbyte and expose them through a Prometheus endpoint as per the [docs](https://docs.airbyte.com/operator-guides/collecting-metrics#helm-chart-setup-instructions). A future PR will modify the `values.yaml` file of the Airbyte deployment to connect it to this OpenTelemetry service, as well as add a definition for a Grafana dashboard based on the collected metrics.