### PR TITLE
Enable metrics and read credentials from k8s secret

### DIFF
--- a/charts/airbyte/ci.sh
+++ b/charts/airbyte/ci.sh
@@ -3,14 +3,13 @@
 set -e
 
 export RELEASE_NAME="${RELEASE_NAME:-airbyte}"
-export NAMESPACE="${NAMESPACE:stg-airbyte}"
-export INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-1200s}"
+export INSTALL_TIMEOUT="${INSTALL_TIMEOUT:-600s}"
 
 usage() {
   echo "Airbyte Helm Chart CI Script"
   echo ""
   echo "Usage:"
-  echo "  ./ci.sh [command]"
+  echo "  ./ci.sh [command] [environment]"
   echo ""
   echo "Available Commands"
   echo ""
@@ -22,6 +21,8 @@ usage() {
   echo "update-docs             Regenerates the README.md documentation after making changes to the values.yaml"
   echo "check-docs-updated      Fails if changes values.yaml and README.md documentation are out of sync"
   echo "help                    Displays help about this command"
+  echo "Options:"
+  echo " [environment]          Environment to deploy to (staging or production)"
 }
 
 if ! helm repo list | grep "bitnami" > /dev/null 2>&1; then
@@ -32,6 +33,23 @@ if [ ! -d ./charts ]; then
   helm dep build
 fi
 
+case "$2" in
+  staging)
+    NAMESPACE="stg-airbyte"
+    ;;
+  
+  production)
+    NAMESPACE="prod-airbyte"
+    ;;
+  
+  *)
+    if [[ "$1" == "test" || "$1" == "diagnostics" || "$1" == "install" ]]; then
+        echo "Invalid environment specified (must be staging or production)"
+        usage
+        exit 1
+    fi
+    ;;
+esac
 
 case "$1" in
   lint)

--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -45,12 +45,12 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: airbyte-airbyte-secrets
-                  key: DATABASE_PASSWORD
+                  name: {{ .Values.global.database.secretName }}
+                  key: {{ .Values.global.database.secretValue }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: airbyte-airbyte-secrets
+                  name: {{ .Values.global.database.secretName }}
                   key: DATABASE_USER
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata

--- a/charts/airbyte/templates/airbyte-db.yaml
+++ b/charts/airbyte/templates/airbyte-db.yaml
@@ -43,9 +43,15 @@ spec:
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.postgresqlDatabase }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgresql.postgresqlPassword }}
+              valueFrom:
+                secretKeyRef:
+                  name: airbyte-airbyte-secrets
+                  key: DATABASE_PASSWORD
             - name: POSTGRES_USER
-              value: {{ .Values.postgresql.postgresqlUsername }}
+              valueFrom:
+                secretKeyRef:
+                  name: airbyte-airbyte-secrets
+                  key: DATABASE_USER
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           ports:
@@ -74,5 +80,5 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 500Mi
+          storage: 2Gi
 {{- end }}

--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -40,9 +40,15 @@ spec:
           env:
             # Minio access key and secret key. This must match the S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY declared in /dev/.env.
             - name: MINIO_ROOT_USER
-              value: {{ .Values.minio.auth.rootUser  }}
+              valueFrom:
+                secretKeyRef:
+                  name: airbyte-airbyte-secrets
+                  key: STATE_STORAGE_MINIO_ACCESS_KEY
             - name: MINIO_ROOT_PASSWORD
-              value: {{ .Values.minio.auth.rootPassword }}
+              valueFrom:
+                secretKeyRef:
+                  name: airbyte-airbyte-secrets
+                  key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
           ports:
             - containerPort: 9000
           # Mount the volume into the pod
@@ -102,9 +108,15 @@ spec:
           /usr/bin/mc policy set public myminio/airbyte-dev-logs;"]
       env:
         - name: MINIO_ACCESS_KEY
-          value: {{ .Values.minio.auth.rootUser }}
+          valueFrom:
+            secretKeyRef:
+              name: airbyte-airbyte-secrets
+              key: STATE_STORAGE_MINIO_ACCESS_KEY
         - name: MINIO_SECRET_KEY
-          value: {{ .Values.minio.auth.rootPassword }}
+          valueFrom:
+            secretKeyRef:
+              name: airbyte-airbyte-secrets
+              key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
         - name: MINIO_ENDPOINT
           value: {{ .Values.minio.endpoint }}
 {{ end }}

--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -42,12 +42,12 @@ spec:
             - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:
-                  name: airbyte-airbyte-secrets
+                  name: {{ .Values.global.database.secretName }}
                   key: STATE_STORAGE_MINIO_ACCESS_KEY
             - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: airbyte-airbyte-secrets
+                  name: {{ .Values.global.database.secretName }}
                   key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
           ports:
             - containerPort: 9000
@@ -110,12 +110,12 @@ spec:
         - name: MINIO_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: airbyte-airbyte-secrets
+              name: {{ .Values.global.database.secretName }}
               key: STATE_STORAGE_MINIO_ACCESS_KEY
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airbyte-airbyte-secrets
+              name: {{ .Values.global.database.secretName }}
               key: STATE_STORAGE_MINIO_SECRET_ACCESS_KEY
         - name: MINIO_ENDPOINT
           value: {{ .Values.minio.endpoint }}

--- a/charts/airbyte/templates/minio.yaml
+++ b/charts/airbyte/templates/minio.yaml
@@ -105,7 +105,8 @@ spec:
           /usr/bin/mc mb --ignore-existing myminio/state-storage;
           /usr/bin/mc policy set public myminio/state-storage;
           /usr/bin/mc mb --ignore-existing myminio/airbyte-dev-logs;
-          /usr/bin/mc policy set public myminio/airbyte-dev-logs;"]
+          /usr/bin/mc policy set public myminio/airbyte-dev-logs;
+          /usr/bin/mc ilm import myminio/airbyte-dev-logs <<< '{\"Rules\":[{\"Expiration\":{\"Days\":5},\"Filter\":{\"Prefix\":\"\"},\"Status\":\"Enabled\",\"ID\":\"ttl\"}]}';"]
       env:
         - name: MINIO_ACCESS_KEY
           valueFrom:

--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.deploymentMode "oss"  }}
+{{- if false }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airbyte/templates/secret.yaml
+++ b/charts/airbyte/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if false }}
+{{- if and (eq .Values.global.deploymentMode "oss") (not .Values.global.useExistingSecrets) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -9,6 +9,8 @@ global:
   # -- Edition; "community" or "pro"
   edition: "community"
 
+  useExistingSecrets: true
+
   # -- Environment variables
   env_vars: {}
   # Database configuration override

--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -14,9 +14,9 @@ global:
   # Database configuration override
   database:
     # -- Secret name where database credentials are stored
-    secretName: ""
+    secretName: "airbyte-airbyte-secrets"
     # -- Secret value for database password
-    secretValue: ""
+    secretValue: "DATABASE_PASSWORD"
   state:
     # -- Determines which state storage will be utilized; "MINIO", "S3", or "GCS"
     storage:
@@ -86,10 +86,10 @@ global:
       credentialsJson: ""
   metrics:
     # -- The metric client to configure globally. Supports "otel"
-    metricClient: ""
+    metricClient: "otel"
 
     # -- The open-telemetry-collector endpoint that metrics will be sent to
-    otelCollectorEndpoint: ""
+    otelCollectorEndpoint: "http://otel-collector.stg-airbyte.svc.cluster.local:4317"
   # Jobs resource requests and limits, see http://kubernetes.io/docs/user-guide/compute-resources/
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -652,8 +652,10 @@ server:
   ##   DATABASE_HOST: airbyte-db
   ##   DATABASE_PORT: 5432
   # -- Supply extra env variables to main container using simplified notation
-  env_vars: {}
-
+  env_vars:
+    PUBLISH_METRICS: "true"
+    METRIC_CLIENT: "otel"
+    OTEL_COLLECTOR_ENDPOINT: "http://otel-collector.stg-airbyte.svc.cluster.local:4317"
 ## @section Worker Parameters
 
 worker:
@@ -751,6 +753,10 @@ worker:
   # -- Additional env vars for worker pods
   extraEnv: []
 
+  env_vars:
+    PUBLISH_METRICS: "true"
+    METRIC_CLIENT: "otel"
+    OTEL_COLLECTOR_ENDPOINT: "http://otel-collector.stg-airbyte.svc.cluster.local:4317"
   ## Examples (when using `worker.containerSecurityContext.readOnlyRootFilesystem=true`):
   ## extraVolumeMounts:
   ##   - name: tmpdir
@@ -917,7 +923,7 @@ workload-launcher:
 
 ## @section Metrics parameters
 metrics:
-  enabled: false
+  enabled: true
 
   # -- Number of metrics-reporter replicas
   replicaCount: 1
@@ -1145,7 +1151,7 @@ temporal:
     # -- The pull policy for the temporal image
     pullPolicy: IfNotPresent
     # -- The temporal image tag to use
-    tag: "1.20.1"
+    tag: "1.22.6"
 
   service:
     # -- The Kubernetes Service Type
@@ -1319,10 +1325,10 @@ minio:
     tag: RELEASE.2023-11-20T22-40-07Z
 
   auth:
-    rootUser: minio
-    rootPassword: minio123
+    rootUser: ""
+    rootPassword: ""
   storage:
-    volumeClaimValue: 500Mi
+    volumeClaimValue: 5Gi
 
   # -- Node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
   ##


### PR DESCRIPTION
This PR addresses the following:

- Enables the `airbyte-metrics` service, which connects to the OpenTelemetry collector service defined in #2. Metrics are also collected from the `airbyte-server` and `airbyte-worker` services.
- Modifies the deployment script to account for staging and production environments. The deployment can be run by running `charts/airbyte/ci.sh install <staging>/<production>`.
- Modifies the `airbyte-db` and `airbyte-minio` deployments to read credentials from a k8s secret rather than have them hard-coded in the `values.yaml` file.
- Updates the Temporal deployment to use the latest image `v1.22.6`.
- Prevents the `airbyte-airbyte-secrets` from being created with hard-coded values. This k8s secret must now be created manually before deploying.