### PR TITLE
Fix otel prod overlay

### DIFF
--- a/opentelemetry/overlays/production/kustomization.yaml
+++ b/opentelemetry/overlays/production/kustomization.yaml
@@ -14,9 +14,9 @@ patches:
       - op: replace
         path: /spec/template/metadata/namespace
         value: prod-airbyte
-        - target:
-          kind: Service
-        patch: |
-          - op: replace
-            path: /metadata/namespace
-            value: prod-airbyte
+  - target:
+      kind: Service
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: prod-airbyte


### PR DESCRIPTION
This PR fixes a small issue with the definition of the OpenTelemetry production deployment.