### PR TITLE
Add .canonical.com to no-proxy config

### DIFF
--- a/charts/airbyte/values.yaml
+++ b/charts/airbyte/values.yaml
@@ -749,11 +749,11 @@ worker:
     OTEL_COLLECTOR_ENDPOINT: "http://otel-collector.stg-airbyte.svc.cluster.local:4317"
     JOB_DEFAULT_ENV_http_proxy: http://squid.internal:3128
     JOB_DEFAULT_ENV_https_proxy: http://squid.internal:3128
-    JOB_DEFAULT_ENV_no_proxy: "10.0.0.0/8,localhost,127.0.0.1,.internal,.cluster.local,.local,.svc,airbyte-*"
+    JOB_DEFAULT_ENV_no_proxy: "10.0.0.0/8,localhost,127.0.0.1,.internal,.cluster.local,.local,.svc,airbyte-*,.canonical.com"
     JOB_DEFAULT_ENV_HTTP_PROXY: http://squid.internal:3128
     JOB_DEFAULT_ENV_HTTPS_PROXY: http://squid.internal:3128
-    JOB_DEFAULT_ENV_NO_PROXY: "10.0.0.0/8,localhost,127.0.0.1,.internal,.cluster.local,.local,.svc,airbyte-*"
-    JOB_DEFAULT_ENV_JAVA_TOOL_OPTIONS: "-Dhttp.proxyHost=squid.internal -Dhttp.proxyPort=3128 -Dhttps.proxyHost=squid.internal -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=10.0.0.0|localhost|127.0.0.1|*.internal|*.cluster.local|*.local|*.svc|airbyte-*"
+    JOB_DEFAULT_ENV_NO_PROXY: "10.0.0.0/8,localhost,127.0.0.1,.internal,.cluster.local,.local,.svc,airbyte-*,.canonical.com"
+    JOB_DEFAULT_ENV_JAVA_TOOL_OPTIONS: "-Dhttp.proxyHost=squid.internal -Dhttp.proxyPort=3128 -Dhttps.proxyHost=squid.internal -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=10.0.0.0|localhost|127.0.0.1|*.internal|*.cluster.local|*.local|*.svc|airbyte-*|.canonical.com"
   ## Examples (when using `worker.containerSecurityContext.readOnlyRootFilesystem=true`):
   ## extraVolumeMounts:
   ##   - name: tmpdir


### PR DESCRIPTION
Webhooks don't seem to work (returning a 403 response), adding `.canonical.com` to the no-proxy list in hopes it resolves the issue.